### PR TITLE
Add Screen::all_contents_formatted

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -606,3 +606,23 @@ impl BufWrite for MouseProtocolEncoding {
         }
     }
 }
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct DisableAlternateScreen;
+
+impl BufWrite for DisableAlternateScreen {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\x1b[?1049l");
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct EnableAlternateScreen;
+
+impl BufWrite for EnableAlternateScreen {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\x1b[?1049h");
+    }
+}


### PR DESCRIPTION
I'm thinking of using vt100 in [tab-rs](https://github.com/austinjones/tab-rs/pull/336), to efficiently render a small scrollback buffer.  But I need the entire scrollback contents, including primary and alternate buffers, so that once scrollback has been completed, interaction with the user can proceed with live stdout.

This PR adds all_contents_formatted to Screen, which:
- Fills both the primary and alternate buffer, leaving the currently active buffer visible
- Returns content for all lines in scrollback, not just visible lines