### PR TITLE
Add CSI windows resize handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vt100"
-version = "0.15.2"
+version = "0.15.3"
 authors = ["Jesse Luehrs <doy@tozt.net>"]
 edition = "2021"
 


### PR DESCRIPTION
We are using this library to replay ttyrec format to be able merge different recording together. In ttyrec recording we see the message when user resize it's terminal window.

According to [doc][1] this is valid message: `CSI Ps ; Ps ; Ps t`.

Within this PR I added handler for resize part only which is `b"\x00\x1b[8;{cols};{rows}t"`

[1]: https://invisible-island.net/xterm/ctlseqs/ctlseqs.htm l