### PR TITLE
Support for dim formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   potentially useful but not something that affects the screen itself.
 * Support for xterm window resize request escape codes, via the new callback
   mechanism.
+* Support for dim formatting.
 
 ### Removed
 

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -23,6 +23,7 @@ const TEXT_MODE_BOLD: u8 = 0b0000_0001;
 const TEXT_MODE_ITALIC: u8 = 0b0000_0010;
 const TEXT_MODE_UNDERLINE: u8 = 0b0000_0100;
 const TEXT_MODE_INVERSE: u8 = 0b0000_1000;
+const TEXT_MODE_DIM: u8 = 0b0001_0000;
 
 #[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
 pub struct Attrs {
@@ -80,6 +81,18 @@ impl Attrs {
         }
     }
 
+    pub fn dim(&self) -> bool {
+        self.mode & TEXT_MODE_DIM != 0
+    }
+
+    pub fn set_dim(&mut self, dim: bool) {
+        if dim {
+            self.mode |= TEXT_MODE_DIM;
+        } else {
+            self.mode &= !TEXT_MODE_DIM;
+        }
+    }
+
     pub fn write_escape_code_diff(
         &self,
         contents: &mut Vec<u8>,
@@ -121,6 +134,11 @@ impl Attrs {
             attrs
         } else {
             attrs.inverse(self.inverse())
+        };
+        let attrs = if self.dim() == other.dim() {
+            attrs
+        } else {
+            attrs.dim(self.dim())
         };
 
         attrs.write_buf(contents);

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1334,10 +1334,14 @@ impl Screen {
             match next_param!() {
                 &[0] => self.attrs = crate::attrs::Attrs::default(),
                 &[1] => self.attrs.set_bold(true),
+                &[2] => self.attrs.set_dim(true),
                 &[3] => self.attrs.set_italic(true),
                 &[4] => self.attrs.set_underline(true),
                 &[7] => self.attrs.set_inverse(true),
-                &[22] => self.attrs.set_bold(false),
+                &[22] => {
+                    self.attrs.set_bold(false);
+                    self.attrs.set_dim(false);
+                }
                 &[23] => self.attrs.set_italic(false),
                 &[24] => self.attrs.set_underline(false),
                 &[27] => self.attrs.set_inverse(false),

--- a/src/term.rs
+++ b/src/term.rs
@@ -113,6 +113,7 @@ pub struct Attrs {
     italic: Option<bool>,
     underline: Option<bool>,
     inverse: Option<bool>,
+    dim: Option<bool>,
 }
 
 impl Attrs {
@@ -145,6 +146,11 @@ impl Attrs {
         self.inverse = Some(inverse);
         self
     }
+
+    pub fn dim(mut self, dim: bool) -> Self {
+        self.dim = Some(dim);
+        self
+    }
 }
 
 impl BufWrite for Attrs {
@@ -157,6 +163,7 @@ impl BufWrite for Attrs {
             && self.italic.is_none()
             && self.underline.is_none()
             && self.inverse.is_none()
+            && self.dim.is_none()
         {
             return;
         }
@@ -256,6 +263,14 @@ impl BufWrite for Attrs {
                 write_param!(7);
             } else {
                 write_param!(27);
+            }
+        }
+
+        if let Some(dim) = self.dim {
+            if dim {
+                write_param!(2);
+            } else {
+                write_param!(22);
             }
         }
 


### PR DESCRIPTION
Uses the code `2` to initiate dim formatting and `22` to exit it. `22` is also used to exit bold formatting.

I looked the codes up at https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters