### PR TITLE
Fix scrollback offset bugs

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -122,7 +122,14 @@ impl Grid {
         self.scrollback
             .iter()
             .skip(scrollback_len - self.scrollback_offset)
-            .chain(self.rows.iter().take(rows_len - self.scrollback_offset))
+            // when scrollback_offset > rows_len (e.g. rows = 3,
+            // scrollback_len = 10, offset = 9) the skip(10 - 9)
+            // will take 9 rows instead of 3. we need to set
+            // the upper bound to rows_len (e.g. 3)
+            .take(rows_len)
+            // same for rows_len - scrollback_offset (e.g. 3 - 9).
+            // it'll panic with overflow. we have to saturate the subtraction.
+            .chain(self.rows.iter().take(rows_len.saturating_sub(self.scrollback_offset)))
     }
 
     pub fn drawing_rows(&self) -> impl Iterator<Item = &crate::row::Row> {


### PR DESCRIPTION
When scrollback length is larger than visible rows. There're 2 issues that I've found.

**Example config**
```rs
let mut p = vt100::Parser::new(3, n, 10)
p.screen_mut().set_scrollback(6);
```
**1. Extra rows returned**
The `.skip` method will skip the first 4 (10 - 6 = 4) rows, thus it'll return 6 rows in total.
Even though we only want 3. 

This is fixed by setting the upper bound via `.take(rows_len)`.

**2. Subtraction overflow**
The `.chain` method will take additional rows via `rows_len - offset` i.e. 3 - 6 = overflow! We just need 0 rows.

This is fixed by using saturation.

Fix #4 #5 