### PR TITLE
Fix Scrollback issues.

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -63,6 +63,10 @@ impl Grid {
         self.size
     }
 
+    pub fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+
     pub fn set_size(&mut self, size: Size) {
         if size.cols != self.size.cols {
             for row in &mut self.rows {
@@ -122,7 +126,7 @@ impl Grid {
         self.scrollback
             .iter()
             .skip(scrollback_len - self.scrollback_offset)
-            .chain(self.rows.iter().take(rows_len - self.scrollback_offset))
+            .chain(self.rows.iter().take(rows_len.saturating_sub(self.scrollback_offset)))
     }
 
     pub fn drawing_rows(&self) -> impl Iterator<Item = &crate::row::Row> {

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -107,6 +107,10 @@ impl Screen {
             .set_size(crate::grid::Size { rows, cols });
     }
 
+    pub fn scrollback_rows(&self) -> usize {
+        self.grid.row_count()
+    }
+
     /// Returns the current size of the terminal.
     ///
     /// The return value will be (rows, cols).


### PR DESCRIPTION
Fix over-scrollback-ing (sub to saturating_sub), and allow third parties to determine if scrollback should be actionable via `screen.scrollback_rows()`