### PR TITLE
feat: expose scrollback buffer with scrollback_rows(), scrollback_row_count(), and clear_scrollback() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+* `Screen::scrollback_rows` to iterate over scrollback buffer contents by row,
+  matching the API of `Screen::rows`.
+* `Screen::scrollback_row_count` to get the number of rows currently stored in
+  the scrollback buffer.
+* `Screen::clear_scrollback` to clear all content from the scrollback buffer.
+
 ## [0.16.2] - 2025-07-11
 
 ### Fixed

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -199,7 +199,7 @@ impl Grid {
         self.scrollback_offset = rows.min(self.scrollback.len());
     }
 
-    pub fn scrollback_rows(&self) -> impl Iterator<Item = &crate::Row> {
+    pub fn scrollback_rows(&self) -> impl Iterator<Item = &crate::row::Row> {
         self.scrollback.iter()
     }
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -199,6 +199,19 @@ impl Grid {
         self.scrollback_offset = rows.min(self.scrollback.len());
     }
 
+    pub fn scrollback_rows(&self) -> impl Iterator<Item = &crate::Row> {
+        self.scrollback.iter()
+    }
+
+    pub fn scrollback_row_count(&self) -> usize {
+        self.scrollback.len()
+    }
+
+    pub fn clear_scrollback(&mut self) {
+        self.scrollback.clear();
+        self.scrollback_offset = 0;
+    }
+
     pub fn write_contents(&self, contents: &mut String) {
         let mut wrapping = false;
         for row in self.visible_rows() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,5 +61,4 @@ pub use attrs::Color;
 pub use callbacks::Callbacks;
 pub use cell::Cell;
 pub use parser::Parser;
-pub use row::Row;
 pub use screen::{MouseProtocolEncoding, MouseProtocolMode, Screen};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,4 +61,5 @@ pub use attrs::Color;
 pub use callbacks::Callbacks;
 pub use cell::Cell;
 pub use parser::Parser;
+pub use row::Row;
 pub use screen::{MouseProtocolEncoding, MouseProtocolMode, Screen};

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -129,7 +129,7 @@ impl Screen {
     }
 
     /// Returns an iterator over the scrollback buffer rows.
-    pub fn scrollback_rows(&self) -> impl Iterator<Item = &crate::Row> {
+    pub fn scrollback_rows(&self) -> impl Iterator<Item = &crate::row::Row> {
         self.grid.scrollback_rows()
     }
 

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -114,6 +114,11 @@ impl Screen {
         self.grid_mut().set_scrollback(rows);
     }
 
+    /// Clears all content from the scrollback buffer.
+    pub fn clear_scrollback(&mut self) {
+        self.grid_mut().clear_scrollback();
+    }
+
     /// Returns the current position in the scrollback.
     ///
     /// This position indicates the offset from the top of the screen, and is
@@ -121,6 +126,17 @@ impl Screen {
     #[must_use]
     pub fn scrollback(&self) -> usize {
         self.grid().scrollback()
+    }
+
+    /// Returns an iterator over the scrollback buffer rows.
+    pub fn scrollback_rows(&self) -> impl Iterator<Item = &crate::Row> {
+        self.grid.scrollback_rows()
+    }
+
+    /// Returns the number of rows currently in the scrollback buffer.
+    #[must_use]
+    pub fn scrollback_row_count(&self) -> usize {
+        self.grid.scrollback_row_count()
     }
 
     /// Returns the text contents of the terminal.

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -128,9 +128,23 @@ impl Screen {
         self.grid().scrollback()
     }
 
-    /// Returns an iterator over the scrollback buffer rows.
-    pub fn scrollback_rows(&self) -> impl Iterator<Item = &crate::row::Row> {
-        self.grid.scrollback_rows()
+    /// Returns the text contents of the scrollback buffer by row, restricted
+    /// to the given subset of columns.
+    ///
+    /// This will not include any formatting information, and will be in plain
+    /// text format.
+    ///
+    /// Newlines will not be included.
+    pub fn scrollback_rows(
+        &self,
+        start: u16,
+        width: u16,
+    ) -> impl Iterator<Item = String> + '_ {
+        self.grid.scrollback_rows().map(move |row| {
+            let mut contents = String::new();
+            row.write_contents(&mut contents, start, width, false);
+            contents
+        })
     }
 
     /// Returns the number of rows currently in the scrollback buffer.

--- a/tests/scroll.rs
+++ b/tests/scroll.rs
@@ -235,23 +235,18 @@ fn scrollback_rows() {
     // Should have 5 rows in scrollback (rows 1-5), screen shows 6-8
     assert_eq!(parser.screen().scrollback_row_count(), 5);
 
-    // Verify scrollback contents via iterator
+    // Verify scrollback contents via iterator (API matches rows())
     let scrollback: Vec<String> = parser
         .screen()
-        .scrollback_rows()
-        .map(|row| {
-            let mut contents = String::new();
-            row.write_contents(&mut contents, 0, 20, false);
-            contents.trim_end().to_string()
-        })
+        .scrollback_rows(0, 20)
+        .map(|s| s.trim_end().to_string())
         .collect();
 
     assert_eq!(scrollback, vec!["1", "2", "3", "4", "5"]);
 
-    // Verify we can access cells in scrollback rows
-    let first_row = parser.screen().scrollback_rows().next().unwrap();
-    let cell = first_row.get(0).unwrap();
-    assert_eq!(cell.contents(), "1");
+    // Verify first row content
+    let first_row = parser.screen().scrollback_rows(0, 20).next().unwrap();
+    assert!(first_row.starts_with("1"));
 }
 
 #[test]
@@ -272,7 +267,7 @@ fn clear_scrollback() {
 
     // Verify scrollback is cleared
     assert_eq!(parser.screen().scrollback_row_count(), 0);
-    assert_eq!(parser.screen().scrollback_rows().count(), 0);
+    assert_eq!(parser.screen().scrollback_rows(0, 20).count(), 0);
 
     // Verify scrollback offset is also reset
     assert_eq!(parser.screen().scrollback(), 0);


### PR DESCRIPTION
- Adds `scrollback_rows()` method to retrieve rows from the scrollback buffer
- Adds `scrollback_row_count()` method to get the number of rows in the scrollback buffer
- Adds `clear_scrollback()` method to clear the scrollback buffer

These methods provide access to the scrollback buffer which was previously internal-only, enabling applications to read terminal history and manage scrollback programmatically.