### PR TITLE
Fix 1x1 grid scrolling

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -680,7 +680,7 @@ impl Grid {
             let mut prev_pos = self.pos;
             self.pos.col = 0;
             let scrolled = self.row_inc_scroll(1);
-            prev_pos.row -= scrolled;
+            prev_pos.row = prev_pos.row.saturating_sub(scrolled);
             let new_pos = self.pos;
             self.drawing_row_mut(prev_pos.row)
                 // we assume self.pos.row is always valid, and so prev_pos.row

--- a/tests/scroll.rs
+++ b/tests/scroll.rs
@@ -177,6 +177,15 @@ fn edge_of_screen() {
 }
 
 #[test]
+fn one_row_wrap_does_not_panic() {
+    let mut parser = vt100::Parser::new(1, 1, 10);
+
+    parser.process(b"ab");
+
+    assert_eq!(parser.screen().contents(), "b");
+}
+
+#[test]
 fn scrollback_larger_than_rows() {
     let mut parser = vt100::Parser::new(3, 20, 10);
 


### PR DESCRIPTION
When adding content causes a scroll on a 1x1 grid, it causes an underflow panic:
```
thread 'one_row_wrap_does_not_panic' (18576866) panicked at src/grid.rs:683:13:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR switches to saturating sub to avoid that underflow panic