### PR TITLE
Fix scrollback not accumulating for top-aligned scroll regions

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -563,7 +563,14 @@ impl Grid {
             self.rows
                 .insert(usize::from(self.scroll_bottom) + 1, self.new_row());
             let removed = self.rows.remove(usize::from(self.scroll_top));
-            if self.scrollback_len > 0 && !self.scroll_region_active() {
+            // A scrolled-off row belongs in the scrollback only when it leaves the top of the
+            // screen, i.e. when the scroll region starts at the screen top (scroll_top == 0).
+            // Upstream used `!scroll_region_active()`, which dropped the row whenever ANY scroll
+            // region was set. That broke inline TUIs (e.g. codex) that insert finalized history
+            // via `SetScrollRegion(1..viewport_top)` + `\r\n` / reverse-index — they never built
+            // any scrollback. With `scroll_top == 0`, full-screen scrolling is unchanged and we
+            // save only when the region includes the screen top (matching xterm).
+            if self.scrollback_len > 0 && self.scroll_top == 0 {
                 self.scrollback.push_back(removed);
                 while self.scrollback.len() > self.scrollback_len {
                     self.scrollback.pop_front();
@@ -601,10 +608,6 @@ impl Grid {
 
     fn in_scroll_region(&self) -> bool {
         self.pos.row >= self.scroll_top && self.pos.row <= self.scroll_bottom
-    }
-
-    fn scroll_region_active(&self) -> bool {
-        self.scroll_top != 0 || self.scroll_bottom != self.size.rows - 1
     }
 
     pub fn set_origin_mode(&mut self, mode: bool) {

--- a/tests/scroll.rs
+++ b/tests/scroll.rs
@@ -191,6 +191,28 @@ fn scrollback_larger_than_rows() {
     assert_eq!(parser.screen().contents(), gen_nums(1..=3, "\n"));
 }
 
+#[test]
+fn scrollback_in_top_aligned_region() {
+    // Regression: inline TUIs (e.g. codex) insert finalized history into the scrollback using
+    // `SetScrollRegion(1..viewport_top)` + `\r\n` within the region. When the region top is the
+    // screen top (scroll_top == 0), scrolled-off rows must enter the scrollback — equivalent to
+    // full-screen scrolling, and matching xterm. Upstream's `!scroll_region_active()` dropped
+    // these rows unconditionally, so such TUIs never built any scrollback.
+    let mut parser = vt100::Parser::new(6, 10, 100);
+    parser.process(b"row1\r\nrow2\r\nrow3\r\nrow4\r\nrow5\r\nrow6");
+
+    // Scroll region 1..4 (screen top to row 4), cursor to region bottom, write 3 lines with
+    // newlines -> 3 rows should land in the scrollback.
+    parser.process(b"\x1b[1;4r\x1b[4;1Hh1\r\nh2\r\nh3\r\n\x1b[r");
+
+    parser.screen_mut().set_scrollback(100);
+    assert_eq!(parser.screen().scrollback(), 3);
+    let back = parser.screen().contents();
+    assert!(back.contains("row1"));
+    assert!(back.contains("row2"));
+    assert!(back.contains("row3"));
+}
+
 #[cfg(test)]
 fn gen_nums(range: RangeInclusive<u8>, join: &str) -> String {
     range


### PR DESCRIPTION
## Problem

`Grid::scroll_up` discards scrolled-off rows whenever a scroll region is set, so they never reach the scrollback buffer:

```rust
if self.scrollback_len > 0 && !self.scroll_region_active() {
    self.scrollback.push_back(removed);
    ...
}
```

`scroll_region_active()` is `true` whenever the region isn't the full screen (`scroll_top != 0 || scroll_bottom != rows - 1`). So any scroll-region-scoped scrolling — even when the region includes the top of the screen — drops the removed row instead of saving it.

Per xterm, a line that leaves the top of the screen should enter the scrollback whenever the scroll region includes the top of the screen (`scroll_top == 0`), regardless of `scroll_bottom`.

## How I hit this

Discovered while running [OpenAI Codex CLI](https://github.com/openai/codex) inside a terminal built on this crate. Codex's inline TUI pushes finalized chat history into the host terminal's scrollback using a top-aligned scroll region — `SetScrollRegion(1..viewport_top)` followed by `\r\n` and reverse-index (`ESC M`) — see [`codex-rs/tui/src/insert_history.rs`](https://github.com/openai/codex/blob/main/codex-rs/tui/src/insert_history.rs), and the related discussion in [openai/codex#10331](https://github.com/openai/codex/issues/10331). With this crate that history was silently dropped and the scrollback stayed empty — there was nothing to scroll back to.

Plain full-screen output (e.g. `cat`) is unaffected, since no scroll region is set.

## Fix

Gate the save on "the region includes the screen top":

```rust
if self.scrollback_len > 0 && self.scroll_top == 0 {
```

- **Full-screen scrolling**: unchanged (`scroll_top == 0` holds, identical to before).
- **Region with `scroll_top == 0`, `scroll_bottom < last`** (the inline-TUI case): now saved to scrollback (previously dropped).
- **Region with `scroll_top > 0`** (doesn't reach the screen top): still not saved (lines scroll into the area above the region, not scrollback) — unchanged.

The now-unused private helper `scroll_region_active` is removed.

## Tests

Adds `scrollback_in_top_aligned_region` in `tests/scroll.rs`: sets a `1..4` scroll region, writes lines with newlines, and asserts 3 rows land in the scrollback. It fails on `main` and passes with this change. The full `cargo test` suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
